### PR TITLE
Fix the mysql module

### DIFF
--- a/modules/mysql/manifests/init.pp
+++ b/modules/mysql/manifests/init.pp
@@ -65,7 +65,7 @@ log_error=/var/log/mysql/error.log"
       require => [
         Package['mysql-common'],
         Package['mysql-server'],
-        File['/lib/systemd/system/mysqld.service']
+        File['/lib/systemd/system/mariadb.service']
       ],
   }
         
@@ -74,7 +74,7 @@ log_error=/var/log/mysql/error.log"
   #SET PASSWORD FOR 'root'@'localhost' = PASSWORD('password');
   exec { 'mysql_init':
     command => "sudo mysqld --init-file=mysqlpd.txt &",
-    path => '/bin,/sbin,...',
+    path    => '/bin,/sbin,...',
     #the following command to avoid the main command running everytime
     creates => '/home/mysql/isInitTrue.txt',
   }

--- a/modules/mysql/manifests/init.pp
+++ b/modules/mysql/manifests/init.pp
@@ -48,13 +48,6 @@ log_error=/var/log/mysql/error.log"
         File['/etc/systemd/system/mysqld.service']
       ],
   }
-/*  file { '/etc/updatedb.conf':
-    ensure => present,
-  }->
-  file_line { 'prunepaths':
-      path => '/etc/updatedb.conf',
-      line => '/tmp /var/spool /media /home',
-  }*/
   
   file { '/lib/systemd/system/mariadb.service':
       ensure  => present,

--- a/modules/mysql/manifests/init.pp
+++ b/modules/mysql/manifests/init.pp
@@ -16,7 +16,9 @@ innodb_log_file_size=256M
 key_buffer_size=5GB
 log_error=/var/log/mysql/error.log"
 
-  file { '/home/mysql/tmp':
+
+  file { [ '/home/mysql',
+           '/home/mysql/tmp' ]:
       ensure => directory,
       mode  => '1777'
   }

--- a/modules/mysql/manifests/init.pp
+++ b/modules/mysql/manifests/init.pp
@@ -16,42 +16,65 @@ innodb_log_file_size=256M
 key_buffer_size=5GB
 log_error=/var/log/mysql/error.log"
 
-file { '/home/mysql/tmp':
-    ensure => directory,
-    mode  => '1777'
-}
+  file { '/home/mysql/tmp':
+      ensure => directory,
+      mode  => '1777'
+  }
 
-file { '/etc/mysql/my.cnf':
-    ensure => present,
-#  }->
-#    file_line { 'mysqld':
-#      path => '/etc/mysql/my.cnf',
+  file { '/etc/mysql/my.cnf':
+      ensure  => present,
+      require => [
+        Package['mysql-common'],
+        Package['mysql-server']
+      ],
       content => $my_cnf_contents,
-    }
-file { '/etc/systemd/system/mysqld.service':
-    ensure => present,
-    }->
-    file_line { 'protectHome':
-        path => '/etc/systemd/system/mysqld.service',
-        line => 'ProtectHome = true',
-        match => "ProtectHome.*",
-        }
+  }
+
+  file { '/etc/systemd/system/mysqld.service':
+      ensure  => present,
+      require => [
+        Package['mysql-common'],
+        Package['mysql-server']
+      ],
+  }
+
+  file_line { 'protectHome':
+      path    => '/etc/systemd/system/mysqld.service',
+      line    => 'ProtectHome = true',
+      match   => "ProtectHome.*",
+      require => [
+        Package['mysql-common'],
+        Package['mysql-server'],
+        File['/etc/systemd/system/mysqld.service']
+      ],
+  }
 /*  file { '/etc/updatedb.conf':
     ensure => present,
   }->
-    file_line { 'prunepaths':
+  file_line { 'prunepaths':
       path => '/etc/updatedb.conf',
       line => '/tmp /var/spool /media /home',
   }*/
   
-file { '/lib/systemd/system/mariadb.service':
-    ensure => present,
-    }->
-    file_line { 'protectHomeFalse':
-        path => '/lib/systemd/system/mariadb.service',
-        line => 'ProtectHome = false',
-        match => "ProtectHome.*",
-        }
+  file { '/lib/systemd/system/mariadb.service':
+      ensure  => present,
+      require => [
+        Package['mysql-common'],
+        Package['mysql-server'],
+        File['/etc/systemd/system/mysqld.service']
+      ],
+  }
+
+  file_line { 'protectHomeFalse':
+      path    => '/lib/systemd/system/mariadb.service',
+      line    => 'ProtectHome = false',
+      match   => "ProtectHome.*",
+      require => [
+        Package['mysql-common'],
+        Package['mysql-server'],
+        File['/lib/systemd/system/mysqld.service']
+      ],
+  }
         
   #Run the command to initialize the mysql server
   #The mysqld.txt file should have a command of the following syntax:
@@ -62,14 +85,25 @@ file { '/lib/systemd/system/mariadb.service':
     #the following command to avoid the main command running everytime
     creates => '/home/mysql/isInitTrue.txt',
   }
+
   exec { 'mysql_install':
     command => "mysql_install_db",
-    path => '/bin,/sbin,...',
+    path    => '/bin,/sbin,...',
     #the following commands to avoid the main command running everytime
     creates => '/home/mysql/isInitTrue.txt',
-    }
+    require =>  [
+      Package['mysql-common'],
+      Package['mysql-server'],
+      File['/etc/mysql/my.cnf']
+    ]
+  }
+
   exec { 'createFileSuccess':
     command => "touch /home/mysql/isInitTrue.txt",
-    path => '/bin,/sbin,...',  
+    path    => '/bin,/sbin,...',
+    require =>  [
+      Exec['mysql_init'],
+      Exec['mysql_install']
+    ]
   }
 }


### PR DESCRIPTION
This pull request fixes a lot of issues found in the `mysql` module.

Specifically, the execution of this module might fail if it is applied with the property `ordering` set to anything but `manifest`.

I present the errors I get from a single run with `--ordering` set to random.

```
Error: Could not set 'present' on ensure: No such file or directory @ dir_s_mkdir - /etc/mysql/my.cnf20190120-10-wlxqei.lock at /root/s
tereoConfig/modules/mysql/manifests/init.pp:24                                                                                         
Error: Could not set 'present' on ensure: No such file or directory @ dir_s_mkdir - /etc/mysql/my.cnf20190120-10-wlxqei.lock at /root/s
tereoConfig/modules/mysql/manifests/init.pp:24                                                                                         
Wrapped exception:                                                                                                                     
No such file or directory @ dir_s_mkdir - /etc/mysql/my.cnf20190120-10-wlxqei.lock                                                     
Error: /Stage[main]/Mysql/File[/etc/mysql/my.cnf]/ensure: change from absent to present failed: Could not set 'present' on ensure: No s
uch file or directory @ dir_s_mkdir - /etc/mysql/my.cnf20190120-10-wlxqei.lock at /root/stereoConfig/modules/mysql/manifests/init.pp:24
```

```
Error: Could not find command 'mysql_install_db'                                                                                       
Error: /Stage[main]/Mysql/Exec[mysql_install]/returns: change from notrun to 0 failed: Could not find command 'mysql_install_db' 
```

Beyond that, the `mysql` module exhibits one more issue. If we run this module in a clean environment and the resource `Exec[createFileSuccess]` runs before the resource `Exec['mysql_init']` or `Exec['mysql_install']`, the latter commands will not be triggered because they are dependent on the condition `creates => "isInitTrue.txt"` which is created by the `Exec['createFileSuccess']`.
Therefore, the mysql might not be installed at all.

To this end, this pull request adds all the required ordering relationships between the puppet resources of the mysql module.